### PR TITLE
Added SSOAdminTools to OpenAM docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,17 @@ ARG OPENAM_VERSION=13.0.0
 ARG OPENAM_KEYSTORE_PASSWORD=changeit
 
 ENV OPENAM_DOWNLOAD_URL http://maven.forgerock.org/repo/releases/org/forgerock/openam/openam-server/${OPENAM_VERSION}/openam-server-${OPENAM_VERSION}.war
+ENV SSOTOOLS_DOWNLOAD_URL http://maven.forgerock.org/repo/releases/org/forgerock/openam/openam-distribution-ssoadmintools/${OPENAM_VERSION}/openam-distribution-ssoadmintools-${OPENAM_VERSION}.zip
 ENV CATALINA_OPTS="-Xmx2048m -server"
 
 RUN curl -#fL "${OPENAM_DOWNLOAD_URL}" -o openam.war \
     && unzip openam.war -d $CATALINA_HOME/webapps/openam \
     && rm -f openam.war
+
+RUN curl -#fL "${SSOTOOLS_DOWNLOAD_URL}" -o ssoadmintools.zip \
+    && mkdir -p /root/ssoadmintools \
+    && unzip ssoadmintools.zip -d /root/ssoadmintools \
+    && rm -f ssoadmintools.zip
 
 RUN openssl req -new -newkey rsa:2048 -nodes -out /opt/server.csr -keyout /opt/server.key -subj "/C=DE/ST=Berlin/L=Berlin/O=Zalando SE/OU=Technology/CN=openam.dev" \
     && openssl x509 -req -days 365 -in /opt/server.csr -signkey /opt/server.key -out /opt/server.crt \

--- a/README.md
+++ b/README.md
@@ -18,5 +18,7 @@ docker build --build-arg OPENAM_VERSION=12.0.0 --build-arg OPENAM_KEYSTORE_PASSW
 docker run --name openam -p 8443:8443 -d openam
 ```
 
-#### URL
-<https://localhost:8443/openam>
+#### Usage
+After building and running the image the OpenAM interface can be found at: <https://localhost:8443/openam>.
+
+In the Docker image itself the SSOAdminTools (with utilities like `ampassword`) can be found in `/root/ssoadmintools`. Since the SSOAdminTools are tied to a specific OpenAM instances you need to run `setup` in the Docker image after you have completed the OpenAM setup.


### PR DESCRIPTION
I've added the downloading and installing of the SSOAdminTools zip to the image creation. This allows the use of tools like `ampassword` which can come in handy when experimenting with signing keys and such.
